### PR TITLE
Added CentOS-servers group

### DIFF
--- a/Ansible/inventories/inventory.za-nwu-vaal
+++ b/Ansible/inventories/inventory.za-nwu-vaal
@@ -51,15 +51,15 @@ cream-ces
 
 
 ############ grouping and children ############
+
 [site-services:children]
 site-bdiis
 cream-ces
 worker-nodes
 
-############## Service oriented grouping ##############
-# (here comes the magical power of ansible... Group things
-# in as much as you can)
-
+[CentOS-servers:children]
+# All site services are CentOS machines
+site-services
 
 ############## Middleware oriented grouping ##############
 


### PR DESCRIPTION
This group `CentOS-servers` has the associated vars file in `group_vars` which defines variables needed in the `common` role.
